### PR TITLE
Fix first arg in torch.arange

### DIFF
--- a/lectures/makemore/makemore_part2_mlp.ipynb
+++ b/lectures/makemore/makemore_part2_mlp.ipynb
@@ -245,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loss = -prob[torch.arange(32), Y].log().mean()\n",
+    "loss = -prob[torch.arange(prob.shape[0]), Y].log().mean()\n",
     "loss"
    ]
   },
@@ -585,7 +585,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -599,7 +599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hey Andrej,
This fixes a shape mismatch error thrown in `torch.arange(...)`. It seems like in the video it's `words[:5]` (hence 32 rows in `prob`) but in the final notebook, it's *all* words (hence >32 rows in `prob`).