### PR TITLE
Correct loss calc from SSE to MSE in backprop loop

### DIFF
--- a/lectures/micrograd/micrograd_lecture_second_half_roughly.ipynb
+++ b/lectures/micrograd/micrograd_lecture_second_half_roughly.ipynb
@@ -1203,7 +1203,7 @@
     "  \n",
     "  # forward pass\n",
     "  ypred = [n(x) for x in xs]\n",
-    "  loss = sum((yout - ygt)**2 for ygt, yout in zip(ys, ypred))\n",
+    "  loss = sum((yout - ygt)**2 for ygt, yout in zip(ys, ypred)) / len(ys) # Video lecture calculates loss as SSE. Corrected to MSE here.\n",
     "  \n",
     "  # backward pass\n",
     "  for p in n.parameters():\n",


### PR DESCRIPTION
SSE is used for loss rather than MSE (~1:54:30 in the video lecture) 

Using len(ys) for n -- MSE = SSE / n