### PR TITLE
Fixing typo in notebook

### DIFF
--- a/lectures/makemore/makemore_part1_bigrams.ipynb
+++ b/lectures/makemore/makemore_part1_bigrams.ipynb
@@ -1357,7 +1357,7 @@
     }
    ],
    "source": [
-    "W = torch.randn((27, 1))\n",
+    "W = torch.randn((27, 27))\n",
     "xenc @ W"
    ]
   },


### PR DESCRIPTION
W needs to be a 27x27 matrix, not 27x1. This typo can trip people up, specially beginners.

Since xenc is 5x27, only when W is 27x27, will you get a 5x27 matrix for xenc@W, like you see subsequently in this notebook.

Even in the video you'll see that this was 27x27 initially but switches to 27x1 after an editing cut (presumably something was Cmd+Z'd in between): https://youtu.be/PaCmpygFfXo?t=4681